### PR TITLE
Fix daily reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,6 +257,7 @@
 
   <script>
     const STORAGE_KEY = 'odin_tasks';
+    const maxCharacters = 5; // Максимальное число персонажей
 
     function loadTasks() {
       return JSON.parse(localStorage.getItem(STORAGE_KEY)) || {};


### PR DESCRIPTION
## Summary
- define maxCharacters constant
- reset logic uses this value without error

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849259e8d4c8328b008c5260b2bdcf5